### PR TITLE
Version 0.1: easy refactorings

### DIFF
--- a/Chest-Commands/ChestCommand.class.st
+++ b/Chest-Commands/ChestCommand.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #'accessing - commands classes' }
 ChestCommand class >> chestCodePresenterCommandClasses [
 
-	^ { ChestLoadObjectIntoCode }
+	^ { ChestLoadObjectIntoCodeCommand }
 ]
 
 { #category : #'accessing - commands classes' }

--- a/Chest-Commands/ChestCommandTreeBuilder.class.st
+++ b/Chest-Commands/ChestCommandTreeBuilder.class.st
@@ -76,7 +76,8 @@ ChestCommandTreeBuilder >> buildSpecCommand: commandClass forContext: aContext [
 { #category : #building }
 ChestCommandTreeBuilder >> chestCommandClasses [
 
-	^ { ChestLoadObjectIntoCodeCommand }
+	^ { ChestLoadObjectIntoCodeCommand } select: [ :each | 
+		  each isVisibleForContext: codePresenter ]
 ]
 
 { #category : #accessing }

--- a/Chest-Commands/ChestCommandTreeBuilder.class.st
+++ b/Chest-Commands/ChestCommandTreeBuilder.class.st
@@ -76,7 +76,7 @@ ChestCommandTreeBuilder >> buildSpecCommand: commandClass forContext: aContext [
 { #category : #building }
 ChestCommandTreeBuilder >> chestCommandClasses [
 
-	^ { ChestLoadObjectIntoCode }
+	^ { ChestLoadObjectIntoCodeCommand }
 ]
 
 { #category : #accessing }

--- a/Chest-Commands/ChestLoadObjectIntoCode.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCode.class.st
@@ -73,7 +73,7 @@ ChestLoadObjectIntoCode >> buildChoicePresenter [
 						ifFalse: [ 
 						self loadIntoContextObject: assoc value named: assoc key ] ] ].
 		choicePresenter window close ].
-	choicePresenter layout: choicePresenter storeCommandLayout.
+	choicePresenter layout: choicePresenter loadCommandLayout.
 	^ choicePresenter
 ]
 
@@ -83,14 +83,6 @@ ChestLoadObjectIntoCode >> execute [
 	| choicePresenter |
 	choicePresenter := self buildChoicePresenter.
 	choicePresenter open
-]
-
-{ #category : #testing }
-ChestLoadObjectIntoCode >> isVisibleForContext: aCodePresenter [
-
-	^ aCodePresenter interactionModel isNotNil and: [ 
-		  aCodePresenter interactionModel allSelectors indexOf:
-			  #addBinding: > 0 ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -91,10 +91,10 @@ ChestLoadObjectIntoCodeCommand >> execute [
 	choicePresenter open
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'private - commands' }
 ChestLoadObjectIntoCodeCommand >> loadIntoContextObject: anObject named: objectName [
 
-	| metalink interactionModel |
+	| "metalink" interactionModel |
 	interactionModel := self context interactionModel.
 	interactionModel addBinding:
 		((WorkspaceVariable key: objectName value: anObject)
@@ -111,7 +111,7 @@ ChestLoadObjectIntoCodeCommand >> variableTag [
 	^ self class variableTag
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'private - commands' }
 ChestLoadObjectIntoCodeCommand >> warnUserWhenDeletingBindingWithKey: key withNewValue: newValue [
 
 	| presenter |

--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -31,6 +31,12 @@ ChestLoadObjectIntoCodeCommand class >> defaultShortcutKey [
 	^ $c meta , $l meta
 ]
 
+{ #category : #testing }
+ChestLoadObjectIntoCodeCommand class >> isVisibleForContext: aCodePresenter [
+
+	^ aCodePresenter canLoadBindings
+]
+
 { #category : #accessing }
 ChestLoadObjectIntoCodeCommand class >> variableTag [
 

--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -34,7 +34,7 @@ ChestLoadObjectIntoCodeCommand class >> defaultShortcutKey [
 { #category : #accessing }
 ChestLoadObjectIntoCodeCommand class >> variableTag [
 
-	^ #comesFromChest
+	^ Chest comesFromChestVariableTag
 ]
 
 { #category : #initialization }

--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -4,7 +4,6 @@ Command that allows to load an object or several objects from a chest into a cod
 Class {
 	#name : #ChestLoadObjectIntoCodeCommand,
 	#superclass : #ChestCommand,
-
 	#category : #'Chest-Commands'
 }
 
@@ -75,7 +74,7 @@ ChestLoadObjectIntoCodeCommand >> buildChoicePresenter [
 ]
 
 { #category : #testing }
-ChestLoadObjectIntoCode >> canBeExecuted [
+ChestLoadObjectIntoCodeCommand >> canBeExecuted [
 
 	^ self isVisibleForContext: context
 ]
@@ -88,8 +87,16 @@ ChestLoadObjectIntoCodeCommand >> execute [
 	choicePresenter open
 ]
 
+{ #category : #testing }
+ChestLoadObjectIntoCodeCommand >> isVisibleForContext: aCodePresenter [
+
+	^ aCodePresenter interactionModel isNotNil and: [ 
+		  aCodePresenter interactionModel class allSelectors 
+			  identityIncludes: #addBinding: ]
+]
+
 { #category : #'private - commands' }
-ChestLoadObjectIntoCode >> loadIntoContextObject: anObject named: objectName [
+ChestLoadObjectIntoCodeCommand >> loadIntoContextObject: anObject named: objectName [
 
 	| interactionModel |
 	interactionModel := self context interactionModel.

--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -2,43 +2,43 @@
 Command that allows to load an object or several objects from a chest into a code presenter in a playground or in a debugger.
 "
 Class {
-	#name : #ChestLoadObjectIntoCode,
+	#name : #ChestLoadObjectIntoCodeCommand,
 	#superclass : #CmCommand,
 	#category : #'Chest-Commands'
 }
 
 { #category : #'accessing - defaults' }
-ChestLoadObjectIntoCode class >> defaultDescription [
+ChestLoadObjectIntoCodeCommand class >> defaultDescription [
 
 	^ 'Load an object from a chest into a code presenter'
 ]
 
 { #category : #initialization }
-ChestLoadObjectIntoCode class >> defaultIconName [
+ChestLoadObjectIntoCodeCommand class >> defaultIconName [
 
 	^ #group
 ]
 
 { #category : #'accessing - defaults' }
-ChestLoadObjectIntoCode class >> defaultName [
+ChestLoadObjectIntoCodeCommand class >> defaultName [
 
 	^ 'Load object from chest'
 ]
 
 { #category : #default }
-ChestLoadObjectIntoCode class >> defaultShortcutKey [
+ChestLoadObjectIntoCodeCommand class >> defaultShortcutKey [
 
 	^ $c meta , $l meta
 ]
 
 { #category : #accessing }
-ChestLoadObjectIntoCode class >> variableTag [
+ChestLoadObjectIntoCodeCommand class >> variableTag [
 
 	^ #comesFromChest
 ]
 
 { #category : #initialization }
-ChestLoadObjectIntoCode >> buildChoicePresenter [
+ChestLoadObjectIntoCodeCommand >> buildChoicePresenter [
 
 	| choicePresenter |
 	choicePresenter := ChestTableWithContentPresenter new.
@@ -78,7 +78,7 @@ ChestLoadObjectIntoCode >> buildChoicePresenter [
 ]
 
 { #category : #execution }
-ChestLoadObjectIntoCode >> execute [
+ChestLoadObjectIntoCodeCommand >> execute [
 
 	| choicePresenter |
 	choicePresenter := self buildChoicePresenter.
@@ -86,7 +86,7 @@ ChestLoadObjectIntoCode >> execute [
 ]
 
 { #category : #'as yet unclassified' }
-ChestLoadObjectIntoCode >> loadIntoContextObject: anObject named: objectName [
+ChestLoadObjectIntoCodeCommand >> loadIntoContextObject: anObject named: objectName [
 
 	| metalink interactionModel |
 	interactionModel := self context interactionModel.
@@ -100,13 +100,13 @@ ChestLoadObjectIntoCode >> loadIntoContextObject: anObject named: objectName [
 ]
 
 { #category : #accessing }
-ChestLoadObjectIntoCode >> variableTag [ 
+ChestLoadObjectIntoCodeCommand >> variableTag [ 
 
 	^ self class variableTag
 ]
 
 { #category : #'as yet unclassified' }
-ChestLoadObjectIntoCode >> warnUserWhenDeletingBindingWithKey: key withNewValue: newValue [
+ChestLoadObjectIntoCodeCommand >> warnUserWhenDeletingBindingWithKey: key withNewValue: newValue [
 
 	| presenter |
 	presenter := ChestRequestDialogPresenter

--- a/Chest-Commands/ChestStoreObjectCommand.class.st
+++ b/Chest-Commands/ChestStoreObjectCommand.class.st
@@ -31,7 +31,7 @@ ChestStoreObjectCommand class >> defaultShortcutKey [
 	^ $c meta , $s meta
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'private - commands' }
 ChestStoreObjectCommand >> blockToEvaluateToStoreResult: result intoChest: chest withName: objectName withPresenter: choicePresenter [
 
 	^ [ 

--- a/Chest-Commands/SpCodeInteractionModel.extension.st
+++ b/Chest-Commands/SpCodeInteractionModel.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpCodeInteractionModel }
+
+{ #category : #'*Chest-Commands' }
+SpCodeInteractionModel >> canLoadBindings [
+
+	^ false
+]

--- a/Chest-Commands/SpCodePresenter.extension.st
+++ b/Chest-Commands/SpCodePresenter.extension.st
@@ -5,3 +5,9 @@ SpCodePresenter class >> buildChestCommandsGroupWith: aCodePresenter forRoot: ro
 	<extensionCommands>
 	ChestCommandTreeBuilder buildCommandsGroupWith: aCodePresenter forRoot: rootCommandGroup 
 ]
+
+{ #category : #'*Chest-Commands' }
+SpCodePresenter >> canLoadBindings [
+
+	^ self interactionModel canLoadBindings
+]

--- a/Chest-Commands/SpCodeScriptingInteractionModel.extension.st
+++ b/Chest-Commands/SpCodeScriptingInteractionModel.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpCodeScriptingInteractionModel }
+
+{ #category : #'*Chest-Commands' }
+SpCodeScriptingInteractionModel >> canLoadBindings [
+
+	^ true
+]

--- a/Chest-Commands/StDebuggerContextInteractionModel.extension.st
+++ b/Chest-Commands/StDebuggerContextInteractionModel.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StDebuggerContextInteractionModel }
+
+{ #category : #'*Chest-Commands' }
+StDebuggerContextInteractionModel >> canLoadBindings [
+
+	^ true
+]

--- a/Chest-Tests/ChestTest.class.st
+++ b/Chest-Tests/ChestTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #ChestTests,
+	#name : #ChestTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'initialChests'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #accessing }
-ChestTests >> firstChestNameAvailable [
+ChestTest >> firstChestNameAvailable [
 
 	"provides a name of a chest that doesn't already exists"
 
@@ -25,26 +25,34 @@ ChestTests >> firstChestNameAvailable [
 ]
 
 { #category : #running }
-ChestTests >> setUp [
+ChestTest >> setUp [
+
 	"Hooks that subclasses may override to define the fixture of test."
-	initialChests := Chest allChests copy. "Keep a copy of all the chests that currently exist"
+
+	super setUp.
+	initialChests := Chest allChests copy "Keep a copy of all the chests that currently exist"
 ]
 
 { #category : #running }
-ChestTests >> tearDown [
+ChestTest >> tearDown [
+
 	| nowChests |
 	nowChests := Chest allChests copy.
 	"Removing chests that currently exist but did not exist before the test execution"
-	nowChests do: [ :aChest | (initialChests includes: aChest) ifFalse: [ Chest removeChest: aChest ] ].
+	nowChests do: [ :aChest | 
+		(initialChests includes: aChest) ifFalse: [ 
+			Chest removeChest: aChest ] ].
+
+	super tearDown
 ]
 
 { #category : #tests }
-ChestTests >> testAddRemoveToChest [
+ChestTest >> testAddRemoveToChest [
 	self testAddRemoveToChest: Chest new.
 ]
 
 { #category : #tests }
-ChestTests >> testAddRemoveToChest: aChest [
+ChestTest >> testAddRemoveToChest: aChest [
 	| c o1 o2 initialChestSize o1Name o2Name |
 	c := aChest.
 	o1 := Object new.
@@ -64,13 +72,13 @@ ChestTests >> testAddRemoveToChest: aChest [
 ]
 
 { #category : #tests }
-ChestTests >> testAddRemoveToDefaultChest [
+ChestTest >> testAddRemoveToDefaultChest [
 	"Tests that the Chest class itself works as a chest"
 	self testAddRemoveToChest: Chest.
 ]
 
 { #category : #tests }
-ChestTests >> testAddingAnObjectTwiceInSameChestWithDifferentNamesRemoveTheOldKeyForThisObject [
+ChestTest >> testAddingAnObjectTwiceInSameChestWithDifferentNamesRemoveTheOldKeyForThisObject [
 
 	| chest object oldName newName |
 	chest := Chest new.
@@ -86,7 +94,7 @@ ChestTests >> testAddingAnObjectTwiceInSameChestWithDifferentNamesRemoveTheOldKe
 ]
 
 { #category : #tests }
-ChestTests >> testAlwaysGiveFreshIDToNewChests [
+ChestTest >> testAlwaysGiveFreshIDToNewChests [
 	| c1 c2 c3 idList c4 |
 	c1 := Chest new.
 	c2 := Chest new.
@@ -104,7 +112,7 @@ ChestTests >> testAlwaysGiveFreshIDToNewChests [
 ]
 
 { #category : #tests }
-ChestTests >> testAtPutAddsObjectToChestWithCorrectName [
+ChestTest >> testAtPutAddsObjectToChestWithCorrectName [
 
 	| chest object |
 	chest := Chest new.
@@ -118,7 +126,7 @@ ChestTests >> testAtPutAddsObjectToChestWithCorrectName [
 ]
 
 { #category : #tests }
-ChestTests >> testChestCreationWithCustomName [
+ChestTest >> testChestCreationWithCustomName [
 
 	| firstNameAvailable chestWithCustomName |
 	firstNameAvailable := self firstChestNameAvailable.
@@ -134,7 +142,7 @@ ChestTests >> testChestCreationWithCustomName [
 ]
 
 { #category : #tests }
-ChestTests >> testChestCreationWithDefaultName [
+ChestTest >> testChestCreationWithDefaultName [
 
 	| chestWithDefaultName1 chestWithDefaultName2 |
 	chestWithDefaultName1 := Chest new.
@@ -154,7 +162,7 @@ ChestTests >> testChestCreationWithDefaultName [
 ]
 
 { #category : #tests }
-ChestTests >> testChestCreationWithNameThatAlreadyExistsRaisesAnError [
+ChestTest >> testChestCreationWithNameThatAlreadyExistsRaisesAnError [
 
 	| firstNameAvailable |
 	firstNameAvailable := self firstChestNameAvailable.
@@ -169,7 +177,7 @@ ChestTests >> testChestCreationWithNameThatAlreadyExistsRaisesAnError [
 ]
 
 { #category : #tests }
-ChestTests >> testChestDictionaryProvidesCopyOfAllChests [
+ChestTest >> testChestDictionaryProvidesCopyOfAllChests [
 
 	| chestDictionary firstNameAvailable |
 	chestDictionary := Chest chestDictionary.
@@ -183,7 +191,7 @@ ChestTests >> testChestDictionaryProvidesCopyOfAllChests [
 ]
 
 { #category : #tests }
-ChestTests >> testContentsProvidesCopyOfChestContent [
+ChestTest >> testContentsProvidesCopyOfChestContent [
 
 	| chest object contents objectInCopy |
 	chest := Chest new.
@@ -200,13 +208,13 @@ ChestTests >> testContentsProvidesCopyOfChestContent [
 ]
 
 { #category : #tests }
-ChestTests >> testDefaultInstance [
+ChestTest >> testDefaultInstance [
 	"Tests that the default instance of the Chest class does exist"
 	self assert: (Chest defaultInstance isKindOf: Chest).
 ]
 
 { #category : #tests }
-ChestTests >> testEmpty [
+ChestTest >> testEmpty [
 
 	| chest |
 	chest := Chest new.
@@ -227,7 +235,7 @@ ChestTests >> testEmpty [
 ]
 
 { #category : #tests }
-ChestTests >> testEmptyChest [
+ChestTest >> testEmptyChest [
 
 	| chest |
 	chest := Chest new.
@@ -243,7 +251,7 @@ ChestTests >> testEmptyChest [
 ]
 
 { #category : #tests }
-ChestTests >> testGettingChestFromID [
+ChestTest >> testGettingChestFromID [
 	"Tests that retrieving chests by their id works"
 	| c1 c2 |
 	c1 := Chest new.
@@ -256,7 +264,7 @@ ChestTests >> testGettingChestFromID [
 ]
 
 { #category : #tests }
-ChestTests >> testNotifications [
+ChestTest >> testNotifications [
 	"Tests that the Chest class does indeed send the notifications it is supposed to"
 	| l c o |
 	l := ChestEventListenerForTest new.
@@ -285,7 +293,7 @@ ChestTests >> testNotifications [
 ]
 
 { #category : #tests }
-ChestTests >> testRemove [
+ChestTest >> testRemove [
 
 	| chest |
 	chest := Chest new.
@@ -298,7 +306,7 @@ ChestTests >> testRemove [
 ]
 
 { #category : #tests }
-ChestTests >> testRemoveChestNamed [
+ChestTest >> testRemoveChestNamed [
 
 	| chest |
 	chest := Chest new.
@@ -311,7 +319,7 @@ ChestTests >> testRemoveChestNamed [
 ]
 
 { #category : #tests }
-ChestTests >> testRemoveChestNamedWithDefaultInstance [
+ChestTest >> testRemoveChestNamedWithDefaultInstance [
 
 	| chest |
 	chest := Chest defaultInstance.
@@ -320,12 +328,12 @@ ChestTests >> testRemoveChestNamedWithDefaultInstance [
 
 	Chest removeChestNamed: chest name.
 
-	self should: [Chest named: chest name] raise: KeyNotFound.
-	self assert: (Chest defaultInstance == chest) not
+	self should: [ Chest named: chest name ] raise: KeyNotFound.
+	self deny: Chest defaultInstance identicalTo: chest
 ]
 
 { #category : #tests }
-ChestTests >> testRemoveObjectNamedWithExistingObject [
+ChestTest >> testRemoveObjectNamedWithExistingObject [
 
 	| chest |
 	chest := Chest new.
@@ -342,7 +350,7 @@ ChestTests >> testRemoveObjectNamedWithExistingObject [
 ]
 
 { #category : #tests }
-ChestTests >> testRemoveObjectNamedWithObjectThatDoesNotExist [
+ChestTest >> testRemoveObjectNamedWithObjectThatDoesNotExist [
 
 	| chest |
 	chest := Chest new.
@@ -359,7 +367,7 @@ ChestTests >> testRemoveObjectNamedWithObjectThatDoesNotExist [
 ]
 
 { #category : #tests }
-ChestTests >> testRemoveWithDefaultInstance [
+ChestTest >> testRemoveWithDefaultInstance [
 
 	| chest |
 	chest := Chest defaultInstance.
@@ -368,12 +376,12 @@ ChestTests >> testRemoveWithDefaultInstance [
 
 	chest remove.
 
-	self should: [Chest named: chest name] raise: KeyNotFound.
-	self assert: (Chest defaultInstance == chest) not
+	self should: [ Chest named: chest name ] raise: KeyNotFound.
+	self deny: Chest defaultInstance identicalTo: chest
 ]
 
 { #category : #tests }
-ChestTests >> testRenameObjectInto [
+ChestTest >> testRenameObjectInto [
 
 	| chest object |
 	chest := Chest new.
@@ -389,7 +397,7 @@ ChestTests >> testRenameObjectInto [
 ]
 
 { #category : #tests }
-ChestTests >> testRenameObjectIntoRaisesErrorWhenObjectIsNotInChest [
+ChestTest >> testRenameObjectIntoRaisesErrorWhenObjectIsNotInChest [
 
 	| chest objectToBeRenamed objectInChest |
 	chest := Chest new.
@@ -410,7 +418,7 @@ ChestTests >> testRenameObjectIntoRaisesErrorWhenObjectIsNotInChest [
 ]
 
 { #category : #tests }
-ChestTests >> testRenameObjectIntoRaisesErrorWhenObjectOfSameNameAlreadyExists [
+ChestTest >> testRenameObjectIntoRaisesErrorWhenObjectOfSameNameAlreadyExists [
 
 	| chest objectToBeRenamed objectAlreadyHavingNewName |
 	chest := Chest new.
@@ -435,7 +443,7 @@ ChestTests >> testRenameObjectIntoRaisesErrorWhenObjectOfSameNameAlreadyExists [
 ]
 
 { #category : #tests }
-ChestTests >> testRenamingChestChangesItsKeyInDictionary [
+ChestTest >> testRenamingChestChangesItsKeyInDictionary [
 
 	| chest firstNameAvailable oldName |
 	chest := Chest new.
@@ -450,7 +458,7 @@ ChestTests >> testRenamingChestChangesItsKeyInDictionary [
 ]
 
 { #category : #tests }
-ChestTests >> testRenamingChestRaisesErrorWhenChestOfSameNameAlreadyExists [
+ChestTest >> testRenamingChestRaisesErrorWhenChestOfSameNameAlreadyExists [
 
 	| chestToBeRenamed firstNameAvailable oldName chestAlreadyHavingNewName |
 	chestToBeRenamed := Chest new.

--- a/Chest-Tests/ChestTest.class.st
+++ b/Chest-Tests/ChestTest.class.st
@@ -126,7 +126,7 @@ ChestTest >> testAtPutAddsObjectToChestWithCorrectName [
 ]
 
 { #category : #tests }
-ChestTests >> testCannotNameChestWithInvalidName [
+ChestTest >> testCannotNameChestWithInvalidName [
 
 	| chest |
 	chest := Chest new.
@@ -139,7 +139,7 @@ ChestTests >> testCannotNameChestWithInvalidName [
 ]
 
 { #category : #tests }
-ChestTests >> testCannotNameObjectInChestWithInvalidName [
+ChestTest >> testCannotNameObjectInChestWithInvalidName [
 
 	| chest |
 	chest := Chest new.
@@ -156,7 +156,7 @@ ChestTests >> testCannotNameObjectInChestWithInvalidName [
 ]
 
 { #category : #tests }
-ChestTests >> testCannotReNameObjectInChestWithInvalidName [
+ChestTest >> testCannotReNameObjectInChestWithInvalidName [
 
 	| chest object |
 	chest := Chest new.
@@ -180,7 +180,7 @@ ChestTests >> testCannotReNameObjectInChestWithInvalidName [
 ]
 
 { #category : #tests }
-ChestTests >> testChestCreationWithCustomName [
+ChestTest >> testChestCreationWithCustomName [
 
 	| firstNameAvailable chestWithCustomName |
 	firstNameAvailable := self firstChestNameAvailable.

--- a/Chest/Chest.class.st
+++ b/Chest/Chest.class.st
@@ -417,8 +417,6 @@ Chest >> initializeContents [
 	contents := ChestContentDictionary new
 ]
 
-<<<<<<< HEAD
-=======
 { #category : #accessing }
 Chest >> inspectAt: aString [
 
@@ -431,7 +429,6 @@ Chest >> isChest [
 	^ true
 ]
 
->>>>>>> master
 { #category : #api }
 Chest >> name [
 

--- a/Chest/Chest.class.st
+++ b/Chest/Chest.class.st
@@ -368,12 +368,6 @@ Chest >> initializeContents [
 	contents := Dictionary new
 ]
 
-{ #category : #accessing }
-Chest >> inspectAt: aString [
-
-	^ (self contentsPrivate at: aString) inspect
-]
-
 { #category : #api }
 Chest >> name [
 

--- a/Chest/Chest.class.st
+++ b/Chest/Chest.class.st
@@ -170,6 +170,12 @@ Chest class >> chestDictionary [
 	^ ChestDictionary copy
 ]
 
+{ #category : #'accessing - tags' }
+Chest class >> comesFromChestVariableTag [
+
+	^ #comesFromChest
+]
+
 { #category : #api }
 Chest class >> contents [
 

--- a/Chest/ChestAnnouncer.class.st
+++ b/Chest/ChestAnnouncer.class.st
@@ -14,7 +14,7 @@ Class {
 	#category : #Chest
 }
 
-{ #category : #initialization }
+{ #category : #'class initialization' }
 ChestAnnouncer class >> initialize [
 
 	uniqueInstance := self new

--- a/Chest/ChestAssociation.class.st
+++ b/Chest/ChestAssociation.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : #Chest
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 ChestAssociation class >> key: key value: value variableName: variableName [
 
 	^ self new

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -362,15 +362,9 @@ ChestPresenter >> presenterToNameNewChest [
 			  [ Chest newNamed: newChestName ]
 				  on: ChestKeyAlreadyInUseError
 				  do: [ 
-					  | chest |
-					  chest := Chest named: newChestName.
-					  (self confirm: (self warningNamingChest: newChestName))
-						  ifTrue: [ 
-							  chest remove.
-							  Chest newNamed: newChestName ]
-						  ifFalse: [ 
-						  UIManager default inform:
-							  newChestName , ' could not be removed.' ] ] ]
+					  self
+						  privHandlingBlockWhenChestNameInUse: newChestName
+						  ifRemoved: [ Chest newNamed: newChestName ] ] ]
 ]
 
 { #category : #'presenter building' }
@@ -382,15 +376,9 @@ ChestPresenter >> presenterToRenameChest: chest [
 			  [ chest name: newChestName ]
 				  on: ChestKeyAlreadyInUseError
 				  do: [ 
-					  | chestBlockingRenaming |
-					  chestBlockingRenaming := Chest named: newChestName.
-					  (self confirm: (self warningNamingChest: newChestName))
-						  ifTrue: [ 
-							  chestBlockingRenaming remove.
-							  chest name: newChestName ]
-						  ifFalse: [ 
-						  UIManager default inform:
-							  newChestName , ' could not be removed.' ] ] ]
+					  self
+						  privHandlingBlockWhenChestNameInUse: newChestName
+						  ifRemoved: [ chest name: newChestName ] ] ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -406,6 +394,19 @@ ChestPresenter >> presenterToRenameObject: object inChest: chest [
 						  ifTrue: [ 
 							  chest removeObjectNamed: name.
 							  chest renameObject: object into: name ] ] ]
+]
+
+{ #category : #'private - building' }
+ChestPresenter >> privHandlingBlockWhenChestNameInUse: newChestName ifRemoved: aBlock [
+
+	"aBlock can take the removed block as an argument"
+
+	| chest |
+	chest := Chest named: newChestName.
+	(self confirm: (self warningNamingChest: newChestName)) ifFalse: [ 
+		^ self ].
+	chest remove.
+	aBlock cull: chest
 ]
 
 { #category : #removing }

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -490,7 +490,7 @@ ChestPresenter >> title [
 	^ 'Chests'
 ]
 
-{ #category : #updating }
+{ #category : #'ui - dialogs' }
 ChestPresenter >> warningNamingChest: newChestName [
 
 	^ '`' , newChestName
@@ -498,9 +498,8 @@ ChestPresenter >> warningNamingChest: newChestName [
 	  '` is the name of a chest that already exists. If you proceed, all objects in the existing chest will be lost. Are you sure you want to proceed?'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'ui - dialogs' }
 ChestPresenter >> warningNamingObjectInChest: newObjectName [
 
-	^ '`' , newObjectName
-	  , '` already exists in this chest. Do you want to replace it?'
+	^ chestTableWithContent warningNamingObjectInChest: newObjectName
 ]

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -343,7 +343,7 @@ ChestPresenter >> namingQuery [
 	^ 'What name do you want to give to your object?'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> presenterToNameNewChest [
 
 	^ ChestRequestDialogPresenter
@@ -354,8 +354,7 @@ ChestPresenter >> presenterToNameNewChest [
 				  do: [ 
 					  | chest |
 					  chest := Chest named: newChestName.
-					  ((self confirm: (self warningNamingChest: newChestName)) and: [ 
-						   chest ~= Chest defaultInstance ])
+					  (self confirm: (self warningNamingChest: newChestName))
 						  ifTrue: [ 
 							  chest remove.
 							  Chest newNamed: newChestName ]
@@ -364,7 +363,7 @@ ChestPresenter >> presenterToNameNewChest [
 							  newChestName , ' could not be removed.' ] ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> presenterToRenameChest: chest [
 
 	^ ChestRequestDialogPresenter
@@ -375,8 +374,7 @@ ChestPresenter >> presenterToRenameChest: chest [
 				  do: [ 
 					  | chestBlockingRenaming |
 					  chestBlockingRenaming := Chest named: newChestName.
-					  ((self confirm: (self warningNamingChest: newChestName)) and: [ 
-						   chestBlockingRenaming ~= Chest defaultInstance ])
+					  (self confirm: (self warningNamingChest: newChestName))
 						  ifTrue: [ 
 							  chestBlockingRenaming remove.
 							  chest name: newChestName ]

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -343,6 +343,16 @@ ChestPresenter >> namingQuery [
 	^ 'What name do you want to give to your object?'
 ]
 
+{ #category : #'ui - requests' }
+ChestPresenter >> popupWithPresenter: requestPresenter onRightTo: anItem [
+
+	(self newPopover
+		 presenter: requestPresenter;
+		 relativeTo: anItem;
+		 bePositionRight;
+		 yourself) popup
+]
+
 { #category : #'presenter building' }
 ChestPresenter >> presenterToNameNewChest [
 
@@ -440,11 +450,7 @@ ChestPresenter >> requestNameNewChestFromToolbar: toolbar [
 
 	| requestPresenter |
 	requestPresenter := self presenterToNameNewChest.
-	(self newPopover
-		 presenter: requestPresenter;
-		 relativeTo: toolbar;
-		 bePositionRight;
-		 yourself) popup
+	self popupWithPresenter: requestPresenter onRightTo: toolbar
 ]
 
 { #category : #initialization }
@@ -452,11 +458,7 @@ ChestPresenter >> requestRenameChest: chest fromContextMenuItem: anItem [
 
 	| requestPresenter |
 	requestPresenter := self presenterToRenameChest: chest.
-	(self newPopover
-		 presenter: requestPresenter;
-		 relativeTo: anItem;
-		 bePositionRight;
-		 yourself) popup
+	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
 
 { #category : #initialization }
@@ -467,11 +469,7 @@ ChestPresenter >> requestRenameObjectFromChest: object fromContextMenuItem: anIt
 	requestPresenter := self
 		                    presenterToRenameObject: object
 		                    inChest: chest.
-	(self newPopover
-		 presenter: requestPresenter;
-		 relativeTo: anItem;
-		 bePositionRight;
-		 yourself) popup
+	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
 
 { #category : #'as yet unclassified' }

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -55,7 +55,7 @@ ChestPresenter >> addBindingsInPlayground: aCollectionOfBindings [
 		aCollectionOfBindings
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> buildChestContentTableContainerLayout [
 
 	chestTableWithContent chestContentTableContainer
@@ -67,7 +67,7 @@ ChestPresenter >> buildChestContentTableContainerLayout [
 		add: chestTableWithContent chestContentTable
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> buildChestTableContainerLayout [
 
 	chestTableWithContent chestTableContainer
@@ -80,21 +80,21 @@ ChestPresenter >> buildChestTableContainerLayout [
 		add: chestTableWithContent chestsTable
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #binding }
 ChestPresenter >> collectBindingsFromAllChests [
 
 	^ chestsTable items flatCollect: [ :each | 
 		  self collectBindingsFromChest: each ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #binding }
 ChestPresenter >> collectBindingsFromChest: aChest [
 
 	^ aChest contents associations collect: [ :each | 
 		  self convertBindingIntoProperWorkspaceVariable: each ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 ChestPresenter >> convertBindingIntoProperWorkspaceVariable: aBinding [
 
 	^ WorkspaceVariable key: aBinding key value: aBinding value
@@ -106,7 +106,7 @@ ChestPresenter >> debuggerExtensionToolName [
 	^ 'Chest'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #layout }
 ChestPresenter >> debuggerLayout [
 
 	self
@@ -141,7 +141,7 @@ ChestPresenter >> defaultLayout [
 		  yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #layout }
 ChestPresenter >> headerLayoutWithTitle: aString withToolbar: aToolbar [
 
 	^ SpBoxLayout newHorizontal
@@ -150,7 +150,7 @@ ChestPresenter >> headerLayoutWithTitle: aString withToolbar: aToolbar [
 		  yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #helper }
 ChestPresenter >> iconManager [
 
 	^ Smalltalk ui icons
@@ -192,7 +192,7 @@ ChestPresenter >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestContentTableContextMenu [
 
 	^ self newMenu
@@ -232,7 +232,7 @@ ChestPresenter >> makeChestContentTableContextMenu [
 				  action: [ chestContentsTable selectedItem value inspect ] ]
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestContentsTable [
 
 	^ chestContentsTable
@@ -246,7 +246,7 @@ ChestPresenter >> makeChestContentsTable [
 		  yourself
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestContentsTableToolbar [
 
 	| toolbar |
@@ -262,7 +262,7 @@ ChestPresenter >> makeChestContentsTableToolbar [
 	^ toolbar
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestTableContextMenu [
 
 	^ self newMenu
@@ -295,7 +295,7 @@ ChestPresenter >> makeChestTableContextMenu [
 					  self addBindingsInPlayground: self collectBindingsFromAllChests ] ]
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestsTable [
 
 	^ chestsTable
@@ -304,7 +304,7 @@ ChestPresenter >> makeChestsTable [
 		  yourself
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> makeChestsTableToolbar [
 
 	| toolbar |
@@ -324,7 +324,7 @@ ChestPresenter >> makeChestsTableToolbar [
 	^ toolbar
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> makePlayground [
 
 	| newPlayground |
@@ -381,7 +381,7 @@ ChestPresenter >> presenterToRenameChest: chest [
 						  ifRemoved: [ chest name: newChestName ] ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestPresenter >> presenterToRenameObject: object inChest: chest [
 
 	^ ChestRequestDialogPresenter
@@ -446,7 +446,7 @@ ChestPresenter >> removeSelectedItem [
 					chestContentsTable selection selectedIndex - 1 ] ]
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> requestNameNewChestFromToolbar: toolbar [
 
 	| requestPresenter |
@@ -454,7 +454,7 @@ ChestPresenter >> requestNameNewChestFromToolbar: toolbar [
 	self popupWithPresenter: requestPresenter onRightTo: toolbar
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> requestRenameChest: chest fromContextMenuItem: anItem [
 
 	| requestPresenter |
@@ -462,7 +462,7 @@ ChestPresenter >> requestRenameChest: chest fromContextMenuItem: anItem [
 	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestPresenter >> requestRenameObjectFromChest: object fromContextMenuItem: anItem [
 
 	| chest requestPresenter |
@@ -473,7 +473,7 @@ ChestPresenter >> requestRenameObjectFromChest: object fromContextMenuItem: anIt
 	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 ChestPresenter >> selectedChest [
 
 	^ chestsTable selection selectedItem

--- a/Chest/ChestPresenter.class.st
+++ b/Chest/ChestPresenter.class.st
@@ -8,15 +8,6 @@ Class {
 	#classTraits : 'TStDebuggerExtension classTrait',
 	#instVars : [
 		'playground',
-		'helpButton',
-		'emptyButton',
-		'helpExpanded',
-		'descriptionLabel',
-		'helpTitleLabel',
-		'leftSpacerForHelpTitleLabel',
-		'rightSpacerForHelpTitleLabel',
-		'helpText',
-		'objectTable',
 		'chestsTable',
 		'chestsTableToolbar',
 		'chestContentsTable',
@@ -62,17 +53,6 @@ ChestPresenter >> addBindingsInPlayground: aCollectionOfBindings [
 
 	playground firstPage interactionModel addBindings:
 		aCollectionOfBindings
-]
-
-{ #category : #adding }
-ChestPresenter >> addButtonsToPresenter: aDialogPresenter withConfirmAction: aBlock [
-
-	| dialogLayout |
-	dialogLayout := aDialogPresenter layout.
-	dialogLayout add: (SpButtonPresenter new
-			 label: 'Confirm';
-			 action: aBlock;
-			 yourself)
 ]
 
 { #category : #'as yet unclassified' }
@@ -170,50 +150,6 @@ ChestPresenter >> headerLayoutWithTitle: aString withToolbar: aToolbar [
 		  yourself
 ]
 
-{ #category : #updating }
-ChestPresenter >> helpText [
-
-	^ 'THIS IS THE HELP FOR CHESTS' , Character cr asString
-	  , Character cr asString , 'ID' , Character cr asString
-	  ,
-	  '	Each Chest instance has an ID (Integer). These IDs are unique. No two Chest can ever have the same ID (unless of course one re-initialize the Chest class).'
-	  , Character cr asString , Character cr asString , 'Default Chest'
-	  , Character cr asString
-	  ,
-	  '	This is an instance of Chest that always exists, always has ID = 1, and can be interacted with in the same way as any other Chest by sending the messages to the Chest class.'
-	  , Character cr asString , Character cr asString , 'API'
-	  , Character cr asString , '	Chest class' , Character cr asString
-	  , '		#new' , Character cr asString
-	  , '			Create and return a new Chest' , Character cr asString
-	  , '		#newNamed: aString' , Character cr asString
-	  , '			Create and return a new Chest, with the provided name'
-	  , Character cr asString , '		#withId: anInteger'
-	  , Character cr asString
-	  , '			Return the Chest whose ID is @anInteger'
-	  , Character cr asString , Character cr asString , '	Chest instance'
-	  , Character cr asString , '		#add: anObject'
-	  , Character cr asString , '			Add anObject to this Chest'
-	  , Character cr asString , '		#at: anInteger'
-	  , Character cr asString
-	  , '			Gets the object stored in this Chest at index @anInteger'
-	  , Character cr asString , '		#contents' , Character cr asString
-	  ,
-	  '			Gets an OrderedCollection with the content of this Chest. This collection is a copy so editing it directly does not affect this Chest.'
-	  , Character cr asString , '		#empty' , Character cr asString
-	  , '			Removes all objects from this Chest' , Character cr asString
-	  , '		#name' , Character cr asString
-	  , '			Gets the name of this Chest' , Character cr asString
-	  , '		#id' , Character cr asString , '			Gets the ID of this Chest'
-	  , Character cr asString , '		#remove' , Character cr asString
-	  ,
-	  '			Destroy this Chest (it will no longer appear in the Chest UI)'
-	  , Character cr asString , '		#remove: anObject'
-	  , Character cr asString , '			Remove @anObject from this Chest'
-	  , Character cr asString , '		#removeAt: anInteger'
-	  , Character cr asString
-	  , '			Remove the object ar index @anInteger from this Chest'
-]
-
 { #category : #'as yet unclassified' }
 ChestPresenter >> iconManager [
 
@@ -229,8 +165,7 @@ ChestPresenter >> initialExtent [
 { #category : #initialization }
 ChestPresenter >> initialize [
 
-	super initialize.
-	helpExpanded := false
+	super initialize
 ]
 
 { #category : #initialization }
@@ -245,7 +180,6 @@ ChestPresenter >> initializePresenters [
 	self makeChestContentsTable.
 	chestContentsTableToolbar := self makeChestContentsTableToolbar.
 	inspector := StInspector on: (StInspectorModel on: nil).
-	helpButton := self makeHelpButton.
 	chestsTable selectIndex: 1.
 
 	self layout: self defaultLayout
@@ -388,14 +322,6 @@ ChestPresenter >> makeChestsTableToolbar [
 			 icon: (self iconManager iconNamed: #add);
 			 action: [ self requestNameNewChestFromToolbar: toolbar ]).
 	^ toolbar
-]
-
-{ #category : #initialization }
-ChestPresenter >> makeHelpButton [
-
-	^ self newButton
-		  action: [ UIManager default notify: self helpText ];
-		  icon: ((self iconNamed: #help) scaledToSize: 16 @ 16)
 ]
 
 { #category : #'as yet unclassified' }

--- a/Chest/ChestTableWithContentPresenter.class.st
+++ b/Chest/ChestTableWithContentPresenter.class.st
@@ -800,7 +800,7 @@ ChestTableWithContentPresenter >> requestRenameChest: chest fromContextMenuItem:
 
 	| requestPresenter |
 	requestPresenter := self presenterToRenameChest: chest.
-	popupWithPresenter: requestPresenter onRightTo: anItem
+	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
 
 { #category : #'ui - dialogs' }

--- a/Chest/ChestTableWithContentPresenter.class.st
+++ b/Chest/ChestTableWithContentPresenter.class.st
@@ -9,6 +9,8 @@ Class {
 		'chestContentsTable',
 		'inputField',
 		'confirmActionBar',
+		'confirmButton',
+		'cancelButton',
 		'chestTableContainer',
 		'chestContentTableContainer'
 	],
@@ -18,7 +20,7 @@ Class {
 { #category : #accessing }
 ChestTableWithContentPresenter >> cancelButton [
 
-	^ self confirmActionBar presenters last
+	^ cancelButton
 ]
 
 { #category : #updating }
@@ -79,7 +81,7 @@ ChestTableWithContentPresenter >> confirmActionBar [
 { #category : #accessing }
 ChestTableWithContentPresenter >> confirmButton [
 
-	^ self confirmActionBar presenters first
+	^ confirmButton
 ]
 
 { #category : #initialization }
@@ -200,17 +202,21 @@ ChestTableWithContentPresenter >> makeChestsTable [
 		  yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 ChestTableWithContentPresenter >> makeConfirmActionBar [
 
+	confirmButton := self newButton
+		                 label: 'Confirm';
+		                 yourself.
+
+	cancelButton := self newButton
+		                label: 'Cancel';
+		                action: [ self window close ];
+		                yourself.
+
 	^ self newActionBar
-		  add: (self newButton
-				   label: 'Confirm';
-				   yourself);
-		  add: (self newButton
-				   label: 'Cancel';
-				   action: [ self window close ];
-				   yourself);
+		  add: confirmButton;
+		  add: cancelButton;
 		  yourself
 ]
 

--- a/Chest/ChestTableWithContentPresenter.class.st
+++ b/Chest/ChestTableWithContentPresenter.class.st
@@ -39,6 +39,21 @@ ChestTableWithContentPresenter >> chestTableContainer [
 	^ chestTableContainer
 ]
 
+{ #category : #accessing }
+ChestTableWithContentPresenter >> chestTableTransmitBlock [
+
+	^ [ :aChest | 
+	  aChest
+		  ifNotNil: [ 
+			  self updateChestContentTableForChest: aChest.
+			  chestContentsTable items ifNotEmpty: [ 
+				  chestContentsTable selectIndex: 1 ].
+			  inputField text: aChest nextDefaultNameForObject ]
+		  ifNil: [ 
+			  chestContentsTable items: {  } asOrderedCollection.
+			  inputField text: '' ] ]
+]
+
 { #category : #updating }
 ChestTableWithContentPresenter >> chestsTable [
 
@@ -71,16 +86,7 @@ ChestTableWithContentPresenter >> confirmButton [
 ChestTableWithContentPresenter >> connectPresenters [
 
 	chestsTable
-		transmitDo: [ :aChest | 
-			aChest
-				ifNotNil: [ 
-					self updateChestContentTableForChest: aChest.
-					chestContentsTable items ifNotEmpty: [ 
-							chestContentsTable selectIndex: 1 ].
-					inputField text: aChest nextDefaultNameForObject ]
-				ifNil: [ 
-					chestContentsTable items: {  } asOrderedCollection.
-					inputField text: '' ] ];
+		transmitDo: self chestTableTransmitBlock;
 		selectFirst
 ]
 

--- a/Chest/ChestTableWithContentPresenter.class.st
+++ b/Chest/ChestTableWithContentPresenter.class.st
@@ -819,7 +819,6 @@ ChestTableWithContentPresenter >> requestRenameObjectFromChest: objectNameValueA
 		                    inChest: chest.
 	self popupWithPresenter: requestPresenter onRightTo: anItem
 ]
->>>>>>> master
 
 { #category : #accessing }
 ChestTableWithContentPresenter >> selectedChest [

--- a/Chest/ChestTableWithContentPresenter.class.st
+++ b/Chest/ChestTableWithContentPresenter.class.st
@@ -29,13 +29,13 @@ ChestTableWithContentPresenter >> chestContentTable [
 	^ chestContentsTable
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 ChestTableWithContentPresenter >> chestContentTableContainer [
 
 	^ chestContentTableContainer
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 ChestTableWithContentPresenter >> chestTableContainer [
 
 	^ chestTableContainer
@@ -161,7 +161,7 @@ ChestTableWithContentPresenter >> inputField [
 	^ inputField
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #layout }
 ChestTableWithContentPresenter >> loadCommandLayout [
 
 	self chestTableContainer
@@ -178,7 +178,7 @@ ChestTableWithContentPresenter >> loadCommandLayout [
 		  yourself
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestTableWithContentPresenter >> makeChestContentsTable [
 
 	^ self newTable
@@ -191,7 +191,7 @@ ChestTableWithContentPresenter >> makeChestContentsTable [
 		  items: #(  ) asOrderedCollection
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestTableWithContentPresenter >> makeChestsTable [
 
 	^ self newList
@@ -202,7 +202,7 @@ ChestTableWithContentPresenter >> makeChestsTable [
 		  yourself
 ]
 
-{ #category : #initialization }
+{ #category : #'presenter building' }
 ChestTableWithContentPresenter >> makeConfirmActionBar [
 
 	confirmButton := self newButton
@@ -220,7 +220,7 @@ ChestTableWithContentPresenter >> makeConfirmActionBar [
 		  yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'presenter building' }
 ChestTableWithContentPresenter >> makeInputField [
 
 	^ self newTextInput
@@ -232,7 +232,7 @@ ChestTableWithContentPresenter >> makeInputField [
 		  yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #layout }
 ChestTableWithContentPresenter >> storeCommandLayout [
 
 	self chestTableContainer
@@ -258,7 +258,7 @@ ChestTableWithContentPresenter >> subscribeToChestAnnouncer [
 		subscribeToChestRemovedAnnouncement
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #subscription }
 ChestTableWithContentPresenter >> subscribeToChestCreatedAnnouncement [
 
 	Chest announcer weak
@@ -267,7 +267,7 @@ ChestTableWithContentPresenter >> subscribeToChestCreatedAnnouncement [
 		to: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #subscription }
 ChestTableWithContentPresenter >> subscribeToChestRemovedAnnouncement [
 
 	Chest announcer weak
@@ -276,7 +276,7 @@ ChestTableWithContentPresenter >> subscribeToChestRemovedAnnouncement [
 		to: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #subscription }
 ChestTableWithContentPresenter >> subscribeToChestUpdatedAnnouncement [
 
 	Chest announcer weak
@@ -291,13 +291,13 @@ ChestTableWithContentPresenter >> title [
 	^ 'Choose a variable name for your object'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #subscription }
 ChestTableWithContentPresenter >> unsubscribeFromChestAnnouncer [
 
 	Chest unsubscribe: self
 ]
 
-{ #category : #initialization }
+{ #category : #update }
 ChestTableWithContentPresenter >> updateChestContentTableForChest: aChest [
 
 	chestContentsTable ifNotNil: [ :lst | 
@@ -310,7 +310,7 @@ ChestTableWithContentPresenter >> updateChestsTable [
 	chestsTable ifNotNil: [ :lst | lst items: Chest allChests ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'ui - dialogs' }
 ChestTableWithContentPresenter >> warningNamingObjectInChest: newObjectName [
 
 	^ '`' , newObjectName

--- a/Chest/StDebuggerExtensionInspectorNodeBuilderVisitor.extension.st
+++ b/Chest/StDebuggerExtensionInspectorNodeBuilderVisitor.extension.st
@@ -7,7 +7,7 @@ StDebuggerExtensionInspectorNodeBuilderVisitor >> visitChest: aChestExtension [
 	debuggerInteractionModel := aChestExtension debugger interactionModel.
 	result := debuggerInteractionModel bindings associations
 		          select: [ :aBinding | 
-			          aBinding propertyAt: #comesFromChest ifAbsent: [ false ] ]
+			          aBinding comesFromChest]
 		          thenCollect: [ :chestVariable | 
 			          (StInspectorDynamicNode
 				           hostObject: chestVariable value


### PR DESCRIPTION
## v 0.1

**Changes:**
* enabling the deletion of the default Chest when naming a new chest or renaming an existing chest with a name identical to the default chest's name
* renaming `ChestLoadObjectIntoCode` into `ChestLoadObjectIntoCodeCommand` 

**Fixes:**
* Fixing a bug because of which the load command could be used in code presenters even if its interaction model couldn't add bindings. Now, this is only possible to add bindings in a playground, in the debugger and in the Chest playground.

**Implementation Notes:**
* adding helpers in `StDebugger` to access its code interactionModel and its bindings more easily 
* cleaning unused methods and inst vars 
* factorizing of the handling block from `on:do:` when another chest has already the name that the user chooses in `ChestPresenter>>#presenterToNameNewChest:` and `ChestPresenter>>#presenterToRenameChest:`
* factorizing code of popovers opening in `ChestPresenter>>#requestRenameChest:fromContextMenuItem` and `requestNameNewChestFromToolbar:` and `ChestPresenter>>#requestRenameObjectFromChest:fromContextMenu:Item:` 
* `ChestPresenter>>#warningNamingObjectInChest:` now delegates to the method of same name in `ChestTableWithContentPresenter`
* factorizing `transmitDo:` blocks in `ChestTableWithContentPresenter`  so that it can be reused in `ChestPresenter` when overriding the `transmitDo:` block
* refactoring`#isVisibleForContext:` by adding a `#canLoadBindings` method in `SpCodeInteractionModel` + taking this into account in `ChestCommandTreeBuilder` so that the load command is only visible if the code presenter's interaction model can add bindings.
* Storing cancel and accept buttons in `ChestTableWithContentPresenter` instead of assuming that they are the last and first button in the `ChestTableWithContentPresenter`'s toolbar 
* making `Variable>>#comesFromChest` access the chest tag via an accessor on `Chest class` so that this tag can be accessed by any class that needs to know it
* classifying methods + removing unused temps + renaming ChestTests into ChestTest + making ChestTest>>#setUp and ChestTest>>#tearDown call `super setUp` and `super tearDown, necessary for green CI *(~~ 30min)*