### PR TITLE
[v0.4] Decoupling UI and logic in store and load commands

### DIFF
--- a/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
+++ b/Chest-Commands/ChestLoadObjectIntoCodeCommand.class.st
@@ -61,13 +61,7 @@ ChestLoadObjectIntoCodeCommand >> buildChoicePresenter [
 		selectedIndexes do: [ :index | 
 			| assoc |
 			assoc := chestContentTable items at: index.
-			(context interactionModel hasBindingOf: assoc key)
-				ifTrue: [ 
-					self
-						warnUserWhenDeletingBindingWithKey: assoc key
-						withNewValue: assoc value ]
-				ifFalse: [ 
-				self loadIntoContextObject: assoc value named: assoc variableName ] ].
+			self loadAssocIntoContext: assoc ].
 		choicePresenter window close ].
 
 	^ choicePresenter
@@ -93,6 +87,18 @@ ChestLoadObjectIntoCodeCommand >> isVisibleForContext: aCodePresenter [
 	^ aCodePresenter interactionModel isNotNil and: [ 
 		  aCodePresenter interactionModel class allSelectors 
 			  identityIncludes: #addBinding: ]
+]
+
+{ #category : #execution }
+ChestLoadObjectIntoCodeCommand >> loadAssocIntoContext: assoc [
+
+	(context interactionModel hasBindingOf: assoc key)
+		ifTrue: [ 
+			self
+				warnUserWhenDeletingBindingWithKey: assoc key
+				withNewValue: assoc value ]
+		ifFalse: [ 
+		self loadIntoContextObject: assoc value named: assoc variableName ]
 ]
 
 { #category : #'private - commands' }

--- a/Chest-Commands/ChestStoreObjectCommand.class.st
+++ b/Chest-Commands/ChestStoreObjectCommand.class.st
@@ -31,17 +31,6 @@ ChestStoreObjectCommand class >> defaultShortcutKey [
 	^ $c meta , $s meta
 ]
 
-{ #category : #'private - commands' }
-ChestStoreObjectCommand >> blockToEvaluateToStoreResult: result intoChest: chest withName: objectName withPresenter: choicePresenter [
-
-	^ [ 
-	  objectName = chest nextDefaultNameForObject
-		  ifTrue: [ self storeObject: result intoChest: chest ]
-		  ifFalse: [ 
-		  self storeObject: result intoChest: chest withName: objectName ].
-	  choicePresenter window close ]
-]
-
 { #category : #initialization }
 ChestStoreObjectCommand >> buildChoicePresenter [
 
@@ -51,24 +40,22 @@ ChestStoreObjectCommand >> buildChoicePresenter [
 		| chest objectName |
 		chest := choicePresenter chestsTable selectedItem.
 		objectName := choicePresenter inputField text.
-		self evaluateSelectionAndDo: [ :result | 
-			(self
-				 blockToEvaluateToStoreResult: result
-				 intoChest: chest
-				 withName: objectName
-				 withPresenter: choicePresenter)
-				on: ChestKeyAlreadyInUseError
-				do: [ 
-					((choicePresenter confirm:
-						  (choicePresenter warningNamingObjectInChest: objectName)) 
-						 onAccept: [ 
-							 chest removeObjectNamed: objectName.
-							 (self
-								  blockToEvaluateToStoreResult: result
-								  intoChest: chest
-								  withName: objectName
-								  withPresenter: choicePresenter) value ]) 
-						openDialogWithParent: choicePresenter chestContentTable ] ] ].
+		[ 
+		self
+			storeSelectionInChest: chest
+			withName: objectName
+			replacing: false ]
+			on: ChestKeyAlreadyInUseError
+			do: [ 
+				((choicePresenter confirm:
+					  (choicePresenter warningNamingObjectInChest: objectName)) 
+					 onAccept: [ 
+						 self
+							 storeSelectionInChest: chest
+							 withName: objectName
+							 replacing: true ]) openDialogWithParent:
+					choicePresenter chestContentTable ].
+		choicePresenter window close ].
 	choicePresenter layout: choicePresenter storeCommandLayout.
 	^ choicePresenter
 ]
@@ -91,4 +78,23 @@ ChestStoreObjectCommand >> storeObject: result intoChest: chest [
 ChestStoreObjectCommand >> storeObject: result intoChest: chest withName: objectName [
 
 	chest ifNotNil: [ chest at: objectName put: result ]
+]
+
+{ #category : #execution }
+ChestStoreObjectCommand >> storeResult: result intoChest: chest withName: objectName replacing: replacingBoolean [
+
+	replacingBoolean ifTrue: [ chest removeObjectNamed: objectName ].
+
+	objectName = chest nextDefaultNameForObject
+		ifTrue: [ self storeObject: result intoChest: chest ]
+		ifFalse: [ 
+		self storeObject: result intoChest: chest withName: objectName ]
+]
+
+{ #category : #execution }
+ChestStoreObjectCommand >> storeSelectionInChest: aChest withName: objectName replacing: replacingBoolean [
+
+	self evaluateSelectionAndDo: [ :result | 
+		self storeResult: result intoChest: aChest withName: objectName replacing: replacingBoolean
+	]
 ]


### PR DESCRIPTION
**Refactorings:**

- Making ChestStoreObjectCommand actually store the object into a chest, instead of letting the presenter do it

- Making ChestLoadObjectCommand actually store the object into a chest, instead of letting the presenter do it